### PR TITLE
WordPress 6.2 Compatibility For Astra Bulk Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit  
 **Requires at least:** 4.4  
-**Tested up to:** 6.1  
+**Tested up to:** 6.2  
 **Stable tag:** 1.2.6  
 **Requires PHP:** 5.2  
 **License:** GPLv2 or later  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit
 Requires at least: 4.4
-Tested up to: 6.1
+Tested up to: 6.2
 Stable tag: 1.2.6
 Requires PHP: 5.2
 License: GPLv2 or later


### PR DESCRIPTION
Summary
- Provided WordPress 6.2 Compatibility.

Changes Made
- Updated Readme "Tested Upto" version to 6.2

Testing
- Tested with Astra 4.1.2, Astra Bulk Edit 1.2.6
- Checked all options if applying correctly on frontend.
- Checked for Pages and Posts.
