### PR TITLE
Fix: Bulk select not working with WP-6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit  
 **Requires at least:** 4.4  
 **Tested up to:** 6.5  
-**Stable tag:** 1.3.0
+**Stable tag:** 1.2.10
 **Requires PHP:** 5.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -61,7 +61,7 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 ## Changelog ##
 
-### 1.3.0 ###
+### 1.2.10 ###
 - Fix: Compatibility issues with WordPress 6.5
 
 ### 1.2.9 ###

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit  
 **Requires at least:** 4.4  
-**Tested up to:** 6.4  
-**Stable tag:** 1.2.9  
+**Tested up to:** 6.5  
+**Stable tag:** 1.3.0
 **Requires PHP:** 5.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -61,9 +61,12 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 ## Changelog ##
 
+### 1.3.0 ###
+- Fix: Compatibility issues with WordPress 6.5
+
 ### 1.2.9 ###
 - Improvement: Compatibility with the Latest Astra Revamped Layout Options.
-- fix: Few bulk edit settings were not working.
+- Fix: Few bulk edit settings were not working.
 
 ### 1.2.8 ###
 - Improved codebase for improved security. (Props - Patchstack)

--- a/astra-bulk-edit.php
+++ b/astra-bulk-edit.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Bulk Edit
  * Plugin URI:  http://www.wpastra.com/pro/
  * Description: Easier way to edit Astra meta options in bulk.
- * Version: 1.3.0
+ * Version: 1.2.10
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Domain Path: /languages
@@ -19,7 +19,7 @@ if ( 'astra' !== get_template() ) {
 /**
  * Set constants.
  */
-define( 'ASTRA_BLK_VER', '1.3.0' );
+define( 'ASTRA_BLK_VER', '1.2.10' );
 define( 'ASTRA_BLK_FILE', __FILE__ );
 define( 'ASTRA_BLK_BASE', plugin_basename( ASTRA_BLK_FILE ) );
 define( 'ASTRA_BLK_DIR', plugin_dir_path( ASTRA_BLK_FILE ) );

--- a/astra-bulk-edit.php
+++ b/astra-bulk-edit.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Bulk Edit
  * Plugin URI:  http://www.wpastra.com/pro/
  * Description: Easier way to edit Astra meta options in bulk.
- * Version: 1.2.9
+ * Version: 1.3.0
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Domain Path: /languages
@@ -19,7 +19,7 @@ if ( 'astra' !== get_template() ) {
 /**
  * Set constants.
  */
-define( 'ASTRA_BLK_VER', '1.2.9' );
+define( 'ASTRA_BLK_VER', '1.3.0' );
 define( 'ASTRA_BLK_FILE', __FILE__ );
 define( 'ASTRA_BLK_BASE', plugin_basename( ASTRA_BLK_FILE ) );
 define( 'ASTRA_BLK_DIR', plugin_dir_path( ASTRA_BLK_FILE ) );

--- a/classes/class-astra-blk-meta-boxes-bulk-edit.php
+++ b/classes/class-astra-blk-meta-boxes-bulk-edit.php
@@ -753,7 +753,7 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 
 			$post_type = get_post_type();
 			if ( 'product' !== $post_type && 'cartflows_flow' !== $post_type && 'cartflows_step' !== $post_type ) {
-				wp_enqueue_script( 'astra-blk-admin', ASTRA_BLK_URI . 'assets/js/astra-admin.js', array( 'jquery', 'inline-edit-post' ), ASTRA_BLK_VER, false );
+				wp_enqueue_script( 'astra-blk-admin', ASTRA_BLK_URI . 'assets/js/astra-admin.js', array( 'jquery', 'inline-edit-post' ), ASTRA_BLK_VER, true );
 				wp_localize_script(
 					'astra-blk-admin',
 					'security',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-bulk-edit",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "Gruntfile.js",
   "author": "",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit
 Requires at least: 4.4
 Tested up to: 6.5
-Stable tag: 1.3.0
+Stable tag: 1.2.10
 Requires PHP: 5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -61,7 +61,7 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 == Changelog ==
 
-### 1.3.0 ###
+### 1.2.10 ###
 - Fix: Compatibility issues with WordPress 6.5
 
 = 1.2.9 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit
 Requires at least: 4.4
-Tested up to: 6.4
-Stable tag: 1.2.9
+Tested up to: 6.5
+Stable tag: 1.3.0
 Requires PHP: 5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -60,6 +60,9 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 
 == Changelog ==
+
+### 1.3.0 ###
+- Fix: Compatibility issues with WordPress 6.5
 
 = 1.2.9 =
 - Improvement: Compatibility with the Latest Astra Revamped Layout Options.


### PR DESCRIPTION
After testing this plugin with WordPress 6.5-RC-3, I found that the default bulk select of WordPress was not working. The reason was the JS hooked to the head rather than the footer, and so did the dependencies were loading earlier than needed.

https://bsf.d.pr/i/6aCgdj