### PR TITLE
fix: Stored XSS in bulk edit AJAX endpoint (Contributor+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 ## Changelog ##
 
 ### 1.2.11 ###
-- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Security Team.
+- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Patchstack.
 - Security: Added proper input sanitization using `sanitize_text_field()` for all meta fields.
 - Security: Added output escaping with `esc_html()` in admin post list columns.
 - Security: Sanitized post ID array input with `absint()`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit  
 **Requires at least:** 4.4  
 **Tested up to:** 6.9  
-**Stable tag:** 1.2.10  
+**Stable tag:** 1.2.11  
 **Requires PHP:** 5.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -60,6 +60,12 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 
 ## Changelog ##
+
+### 1.2.11 ###
+- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Security Team.
+- Security: Added proper input sanitization using `sanitize_text_field()` for all meta fields.
+- Security: Added output escaping with `esc_html()` in admin post list columns.
+- Security: Sanitized post ID array input with `absint()`.
 
 ### 1.2.10 ###
 - Fix: Compatibility issues with WordPress 6.5

--- a/astra-bulk-edit.php
+++ b/astra-bulk-edit.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Bulk Edit
  * Plugin URI:  http://www.wpastra.com/pro/
  * Description: Easier way to edit Astra meta options in bulk.
- * Version: 1.2.10
+ * Version: 1.2.11
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Domain Path: /languages
@@ -19,7 +19,7 @@ if ( 'astra' !== get_template() ) {
 /**
  * Set constants.
  */
-define( 'ASTRA_BLK_VER', '1.2.10' );
+define( 'ASTRA_BLK_VER', '1.2.11' );
 define( 'ASTRA_BLK_FILE', __FILE__ );
 define( 'ASTRA_BLK_BASE', plugin_basename( ASTRA_BLK_FILE ) );
 define( 'ASTRA_BLK_DIR', plugin_dir_path( ASTRA_BLK_FILE ) );

--- a/classes/class-astra-blk-meta-boxes-bulk-edit.php
+++ b/classes/class-astra-blk-meta-boxes-bulk-edit.php
@@ -229,10 +229,6 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 
 				switch ( $sanitize_filter ) {
 
-					case 'FILTER_SANITIZE_STRING':
-							$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_STRING );
-						break;
-
 					case 'FILTER_SANITIZE_URL':
 							$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_URL );
 						break;
@@ -241,14 +237,15 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 							$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_NUMBER_INT );
 						break;
 
+					case 'FILTER_SANITIZE_STRING':
 					default:
-							$meta_value = filter_input( INPUT_POST, $key, FILTER_DEFAULT );
+							$meta_value = isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
 						break;
 				}
 
 				// Store values.
 				if ( 'no-change' !== $meta_value ) {
-					update_post_meta( $post_id, $key, $meta_value );
+					update_post_meta( $post_id, $key, sanitize_text_field( $meta_value ) );
 				}
 			}
 
@@ -263,8 +260,8 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 				wp_send_json_error( esc_html__( 'Action failed. Invalid Security Nonce.', 'astra-bulk-edit' ) );
 			}
 
-			$post_ids = ! empty( $_POST['post'] ) ? $_POST['post'] : array();
-			if ( ! empty( $post_ids ) && is_array( $post_ids ) ) {
+			$post_ids = ! empty( $_POST['post'] ) ? array_map( 'absint', (array) $_POST['post'] ) : array();
+			if ( ! empty( $post_ids ) ) {
 
 				/**
 				 * Get meta options
@@ -280,10 +277,6 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 
 							switch ( $sanitize_filter ) {
 
-								case 'FILTER_SANITIZE_STRING':
-										$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_STRING );
-									break;
-
 								case 'FILTER_SANITIZE_URL':
 										$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_URL );
 									break;
@@ -292,14 +285,15 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 										$meta_value = filter_input( INPUT_POST, $key, FILTER_SANITIZE_NUMBER_INT );
 									break;
 
+								case 'FILTER_SANITIZE_STRING':
 								default:
-										$meta_value = filter_input( INPUT_POST, $key, FILTER_DEFAULT );
+										$meta_value = isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
 									break;
 							}
 
 							// Store values.
 							if ( 'no-change' !== $meta_value ) {
-								update_post_meta( $post_id, $key, $meta_value );
+								update_post_meta( $post_id, $key, sanitize_text_field( $meta_value ) );
 							}
 						}
 					}
@@ -366,11 +360,11 @@ if ( ! class_exists( 'Astra_Blk_Meta_Boxes_Bulk_Edit' ) ) {
 						$default_value = $meta[ $key ]['default'];
 					}
 
-					$html .= $default_value;
+					$html .= esc_html( $default_value );
 					$html .= '</div>';
 				}
 
-				echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- All dynamic values escaped above with esc_html/esc_attr.
 			}
 
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-bulk-edit",
-  "version": "1.3.0",
+  "version": "1.2.11",
   "main": "Gruntfile.js",
   "author": "",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,12 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 
 == Changelog ==
 
+= 1.2.11 =
+- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Security Team.
+- Security: Added proper input sanitization using `sanitize_text_field()` for all meta fields.
+- Security: Added output escaping with `esc_html()` in admin post list columns.
+- Security: Sanitized post ID array input with `absint()`.
+
 ### 1.2.10 ###
 - Fix: Compatibility issues with WordPress 6.5
 

--- a/readme.txt
+++ b/readme.txt
@@ -62,7 +62,7 @@ Astra Bulk Edit plugin can be used only with the Astra theme.
 == Changelog ==
 
 = 1.2.11 =
-- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Security Team.
+- Security: Fixed Stored XSS vulnerability in bulk edit AJAX endpoint (Contributor+). Props - Patchstack.
 - Security: Added proper input sanitization using `sanitize_text_field()` for all meta fields.
 - Security: Added output escaping with `esc_html()` in admin post list columns.
 - Security: Sanitized post ID array input with `absint()`.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit
 Requires at least: 4.4
 Tested up to: 6.9
-Stable tag: 1.2.10
+Stable tag: 1.2.11
 Requires PHP: 5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

- Fixes a **Stored Cross-Site Scripting (XSS)** vulnerability in the `astra_save_post_bulk_edit` AJAX endpoint where a Contributor+ user could inject arbitrary HTML/JS into post meta, executing in any admin's browser session
- Replaces `FILTER_DEFAULT` (no sanitization) with `sanitize_text_field(wp_unslash())` in both `save_post_bulk_edit()` and `save_meta_box()`
- Adds `esc_html()` output escaping in admin post list column rendering
- Sanitizes `$_POST['post']` array with `array_map('absint', ...)`

Fixes #68

## Changes

| File | What changed |
|------|-------------|
| `classes/class-astra-blk-meta-boxes-bulk-edit.php` | Input sanitization + output escaping |
| `readme.txt` | Changelog entry for v1.2.11 |

## Test plan

- [ ] Log in as Contributor, attempt to save `<script>alert(1)</script>` via bulk edit AJAX — should be stripped to plain text
- [ ] Log in as Admin, view post list — no script execution, values display as escaped text
- [ ] Verify normal bulk edit operations (sidebar, header, footer toggles) still work correctly
- [ ] Verify quick edit save path also sanitizes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)