### PR TITLE
chore: add Claude Code scaffolding and internal docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer lint)",
+      "Bash(composer format)",
+      "Bash(grunt readme)",
+      "Bash(grunt i18n)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)"
+    ],
+    "deny": []
+  }
+}

--- a/.distignore
+++ b/.distignore
@@ -33,3 +33,5 @@ node_modules
 .gitattributes
 .github
 .wordpress-org
+.claude
+CLAUDE.md

--- a/.distignore
+++ b/.distignore
@@ -35,3 +35,4 @@ node_modules
 .wordpress-org
 .claude
 CLAUDE.md
+internal-docs

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 *.tar.gz
 *.zip
 vendor/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# Astra Bulk Edit
+
+WordPress plugin for bulk editing Astra theme meta options via Quick Edit and Bulk Edit screens.
+
+## Tech Stack
+
+- **PHP** (WordPress plugin, requires Astra theme active)
+- **WordPress Coding Standards** (WPCS) via phpcs
+- **Grunt** for build tooling (i18n, release packaging, version bumping)
+- **Composer** for dev dependencies (phpcs, phpcompat)
+
+## Commands
+
+```bash
+# Lint PHP (WPCS + PHPCompatibility)
+composer lint
+
+# Auto-fix PHP coding standards
+composer format
+
+# Generate README.md from readme.txt
+grunt readme
+
+# Build release zip
+grunt release
+
+# Bump version (updates package.json + plugin header + constants)
+grunt version-bump --ver=1.2.11
+
+# Generate i18n pot file
+grunt i18n
+```
+
+## Architecture
+
+- `astra-bulk-edit.php` - Main plugin file, defines constants, loads admin class
+- `classes/` - PHP classes (bulk edit meta box handler)
+- `assets/` - Static assets (CSS/JS)
+- `languages/` - Translation files (.pot)
+- `.wordpress-org/` - WP.org assets (banners, icons, screenshots)
+
+## Key Constants
+
+- `ASTRA_BLK_VER` - Plugin version
+- `ASTRA_BLK_FILE` - Main plugin file path
+- `ASTRA_BLK_BASE` - Plugin basename
+- `ASTRA_BLK_DIR` - Plugin directory path
+- `ASTRA_BLK_URI` - Plugin URL
+
+## Conventions
+
+- Follow WPCS (WordPress-Core, WordPress-Docs, WordPress-Extra)
+- PHP compatibility: 5.3+
+- Text domain: `astra-bulk-edit`
+- Plugin only loads when Astra theme is active (`get_template() === 'astra'`)
+- All plugin code runs in admin context only (`is_admin()`)
+
+## Gotchas
+
+- Plugin silently exits if Astra theme is not the active template
+- Version must be updated in both `package.json` and `astra-bulk-edit.php` (use `grunt version-bump`)
+- `readme.txt` is the source of truth; `README.md` is generated via `grunt readme`
+
+## Current Focus
+
+<!-- Update this section with current work priorities -->

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,7 @@ module.exports = function( grunt ) {
 					'!phpcs.xml.dist',
 					'!CLAUDE.md',
 					'!.claude/**',
+					'!internal-docs/**',
 				],
 				dest: 'astra-bulk-edit/'
 			}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,6 +82,8 @@ module.exports = function( grunt ) {
 					'!composer.lock',
 					'!package-lock.json',
 					'!phpcs.xml.dist',
+					'!CLAUDE.md',
+					'!.claude/**',
 				],
 				dest: 'astra-bulk-edit/'
 			}

--- a/internal-docs/README.md
+++ b/internal-docs/README.md
@@ -1,0 +1,56 @@
+# Astra Bulk Edit - Internal Documentation
+
+## Quick Start
+
+```bash
+# Clone and install
+git clone <repo-url>
+cd astra-bulk-edit
+npm install
+composer install
+
+# Lint PHP
+composer lint
+
+# Build release zip
+grunt release
+
+# Generate README.md from readme.txt
+grunt readme
+```
+
+## What Is This Plugin?
+
+Astra Bulk Edit lets WordPress admins modify Astra theme meta settings (sidebar, content layout, header/footer visibility, etc.) across multiple pages/posts at once using WordPress's native Bulk Edit and Quick Edit interfaces.
+
+- **Version:** 1.2.11
+- **Author:** Brainstorm Force
+- **License:** GPLv2+
+- **Requires:** WordPress 4.4+, PHP 5.2+, Astra theme active
+- **Distribution:** WordPress.org
+
+## Key Facts
+
+- Plugin only loads when the Astra theme is the active template
+- All code runs in the admin context (`is_admin()`)
+- Single PHP class handles everything: `Astra_Blk_Meta_Boxes_Bulk_Edit`
+- Supports 22 meta options covering layout, headers, footers, breadcrumbs
+- Integrates with Astra Pro addons (Transparent Header, Sticky Header, Advanced Headers)
+- Includes layout migration for Astra 4.2.0+ revamped options
+
+## Documentation Index
+
+| File | Description |
+|------|-------------|
+| [product-vision.md](product-vision.md) | Goals, personas, competitive landscape |
+| [architecture.md](architecture.md) | High-level architecture and data flow |
+| [codebase-map.md](codebase-map.md) | Folder-by-folder file guide |
+| [apis.md](apis.md) | AJAX endpoints, hooks, and filters |
+| [coding-standards.md](coding-standards.md) | PHP/JS conventions and tooling |
+| [ui-and-copy.md](ui-and-copy.md) | User journeys and microcopy |
+| [onboarding.md](onboarding.md) | Developer onboarding paths |
+| [ai-agent-guide.md](ai-agent-guide.md) | Guidance for AI coding agents |
+| [troubleshooting.md](troubleshooting.md) | Common problems and fixes |
+| [faq.md](faq.md) | Frequently asked questions |
+| [glossary.md](glossary.md) | Technical terms and definitions |
+| [maintenance.md](maintenance.md) | How to update these docs |

--- a/internal-docs/ai-agent-guide.md
+++ b/internal-docs/ai-agent-guide.md
@@ -1,0 +1,69 @@
+# AI Agent Guide
+
+## How AI Agents Should Work With This Plugin
+
+### Before Making Changes
+
+1. **Read `CLAUDE.md`** at the project root for commands and conventions
+2. **Read the main class** (`classes/class-astra-blk-meta-boxes-bulk-edit.php`) - it contains nearly all logic
+3. **Check Astra version conditionals** - many code paths branch on `ASTRA_THEME_VERSION` or `Astra_Builder_Helper::is_header_footer_builder_active()`
+4. **Understand the "no-change" sentinel** - this value means "skip this field" during save, not "set to empty"
+
+### Key Code Locations
+
+| Task | Where to Look |
+|------|---------------|
+| Add a new meta option | `setup_bulk_options()` + `display_quick_edit_custom()` |
+| Fix a save bug | `save_meta_box()` (quick edit) or `save_post_bulk_edit()` (bulk AJAX) |
+| Fix pre-population | `manage_custom_admin_columns()` + `astra-admin.js` |
+| Change UI layout | `display_quick_edit_custom()` (PHP form) + `astra-admin.css` |
+| Fix JS behavior | `assets/js/astra-admin.js` |
+| Add Astra Pro integration | Check `is_callable()` / `Astra_Ext_Extension::is_active()` patterns |
+
+### Common Patterns to Follow
+
+**Adding a new meta option:**
+```php
+// 1. In setup_bulk_options(), add to the $meta_option array:
+'my-new-option' => array(
+    'default'  => 'no-change',
+    'sanitize' => 'FILTER_DEFAULT',
+),
+
+// 2. In display_quick_edit_custom(), add a dropdown:
+<label class="inline-edit" for="my-new-option">
+    <span class="title"><?php esc_html_e( 'My Option', 'astra-bulk-edit' ); ?></span>
+    <select name="my-new-option" id="my-new-option">
+        <option value="no-change" selected="selected"><?php esc_html_e( '-- No Change --', 'astra-bulk-edit' ); ?></option>
+        <option value="enabled"><?php esc_html_e( 'Enabled', 'astra-bulk-edit' ); ?></option>
+        <option value="disabled"><?php esc_html_e( 'Disabled', 'astra-bulk-edit' ); ?></option>
+    </select>
+</label>
+```
+The save logic auto-handles new options (iterates `$meta_option` keys).
+
+### Pitfalls to Avoid
+
+1. **Don't forget both save paths** - Quick edit uses `save_meta_box()` via `save_post` hook; bulk edit uses `save_post_bulk_edit()` via AJAX. Both must handle any new field.
+2. **Don't remove the "no-change" option** - It's essential for bulk edit to not overwrite settings the user didn't intend to change.
+3. **Don't change nonce names** - They're referenced in both PHP and JS.
+4. **Don't add REST endpoints** - This plugin deliberately uses AJAX only for admin operations.
+5. **Don't forget `sanitize_text_field()`** - All meta values must be sanitized before saving.
+6. **Don't use `esc_html_e()` with concatenated strings** - Use `esc_html()` separately for dynamic parts.
+7. **Test with and without Astra Pro** - Many conditionals depend on Pro addon availability.
+
+### Security Checklist
+
+When modifying save/input handling:
+- [ ] Nonce verified before any data processing
+- [ ] `current_user_can('edit_post', $post_id)` checked per-post
+- [ ] All input sanitized (`sanitize_text_field`, `absint`, `filter_input`)
+- [ ] All output escaped (`esc_html`, `esc_attr`)
+- [ ] AJAX handler uses `check_ajax_referer()`
+
+### Build & Version
+
+- Version is defined in TWO places: `package.json` and `astra-bulk-edit.php` (header + constant)
+- Use `grunt version-bump --ver=x.x.x` to update both
+- `readme.txt` is the source of truth; `README.md` is generated via `grunt readme`
+- Release zip: `grunt release`

--- a/internal-docs/apis.md
+++ b/internal-docs/apis.md
@@ -1,0 +1,99 @@
+# APIs - Hooks, Filters, and AJAX
+
+## AJAX Endpoints
+
+### `astra_save_post_bulk_edit`
+- **Type:** `wp_ajax_` (authenticated users only)
+- **Handler:** `Astra_Blk_Meta_Boxes_Bulk_Edit::save_post_bulk_edit()`
+- **File:** `classes/class-astra-blk-meta-boxes-bulk-edit.php:257`
+- **Security:** `check_ajax_referer('astra-blk-nonce', 'astra_nonce')` + per-post `current_user_can('edit_post', $post_id)`
+- **Input:** Serialized form data with post IDs and meta values
+- **Response:** `wp_send_json_success()` or `wp_send_json_error()`
+
+## WordPress Hooks Used
+
+### Actions
+
+| Hook | Method | Priority | File:Line |
+|------|--------|----------|-----------|
+| `admin_init` | `setup_admin_init()` | 999 | :50 |
+| `bulk_edit_custom_box` | `display_quick_edit_custom()` | 10 | :53 |
+| `quick_edit_custom_box` | `display_quick_edit_custom()` | 10 | :54 |
+| `admin_enqueue_scripts` | `enqueue_admin_scripts_and_styles()` | 10 | :56 |
+| `save_post` | `save_meta_box()` | 10 | :58 |
+| `wp_ajax_astra_save_post_bulk_edit` | `save_post_bulk_edit()` | 10 | :60 |
+| `manage_{$type}_posts_columns` | `add_custom_admin_column()` | 10 | :83 |
+| `manage_{$type}_posts_custom_column` | `manage_custom_admin_columns()` | 10 | :85 |
+
+### Dynamic Hooks (per post type)
+The plugin dynamically registers column hooks for every public post type except `attachment` and `fl-theme-layout`.
+
+## Filters
+
+### Provided by This Plugin
+
+#### `astra_meta_box_bulk_edit_options`
+- **File:** `classes/class-astra-blk-meta-boxes-bulk-edit.php:100`
+- **Purpose:** Allows other plugins to modify the list of meta options available in bulk edit
+- **Default:** Array of 22 meta keys with defaults and sanitize rules
+- **Usage:**
+```php
+add_filter( 'astra_meta_box_bulk_edit_options', function( $options ) {
+    $options['my-custom-meta'] = array(
+        'default'  => 'no-change',
+        'sanitize' => 'FILTER_DEFAULT',
+    );
+    return $options;
+});
+```
+
+### Used from Astra Theme
+
+#### `astra_page_title`
+- **File:** `classes/class-astra-blk-meta-boxes-bulk-edit.php:313,384`
+- **Purpose:** Gets the theme display name (supports white-labeling)
+
+## Custom Action Hooks
+
+These fire inside the bulk edit form, allowing extensions to add fields:
+
+| Hook | Location | File:Line |
+|------|----------|-----------|
+| `astra_meta_bulk_edit_left_bottom` | After layout dropdowns | :465 |
+| `astra_meta_bulk_edit_center_bottom` | After header/sticky controls | :663 |
+
+## Meta Keys
+
+All meta values are stored as post meta via `update_post_meta()`. The "no-change" sentinel value means "skip this field" during save.
+
+| Meta Key | Purpose | Values |
+|----------|---------|--------|
+| `site-sidebar-layout` | Sidebar position | `default`, `left-sidebar`, `right-sidebar`, `no-sidebar` |
+| `site-content-layout` | Legacy content layout | `default`, `boxed-container`, `content-boxed-container`, `plain-container`, `page-builder` |
+| `ast-site-content-layout` | Container layout (4.2.0+) | `default`, `normal-width-container`, `narrow-width-container`, `full-width-container` |
+| `site-content-style` | Container style (4.2.0+) | `default`, `unboxed`, `boxed` |
+| `site-sidebar-style` | Sidebar style (4.2.0+) | `default`, `unboxed`, `boxed` |
+| `ast-main-header-display` | Primary header | `enabled`, `disabled` |
+| `ast-above-header-display` | Above header (legacy) | `enabled`, `disabled` |
+| `ast-below-header-display` | Below header (legacy) | `enabled`, `disabled` |
+| `ast-hfb-above-header-display` | Above header (builder) | `enabled`, `disabled` |
+| `ast-hfb-below-header-display` | Below header (builder) | `enabled`, `disabled` |
+| `ast-hfb-mobile-header-display` | Mobile header (builder) | `enabled`, `disabled` |
+| `site-post-title` | Page title visibility | `enabled`, `disabled` |
+| `ast-featured-img` | Featured image | `enabled`, `disabled` |
+| `footer-sml-layout` | Footer bar | `enabled`, `disabled` |
+| `footer-adv-display` | Footer widgets | `enabled`, `disabled` |
+| `ast-breadcrumbs-content` | Breadcrumbs | `enabled`, `disabled` |
+| `theme-transparent-header-meta` | Transparent header | `default`, `enabled`, `disabled` |
+| `stick-header-meta` | Sticky header | `default`, `enabled`, `disabled` |
+| `header-above-stick-meta` | Stick above header | `enabled`, `disabled` |
+| `header-main-stick-meta` | Stick primary header | `enabled`, `disabled` |
+| `header-below-stick-meta` | Stick below header | `enabled`, `disabled` |
+| `adv-header-id-meta` | Page header ID | Post ID of `astra_adv_header` CPT |
+
+## Nonce Details
+
+| Context | Nonce Action | Nonce Field | Verification |
+|---------|-------------|-------------|--------------|
+| Quick Edit | `basename(__FILE__)` | `astra_settings_bulk_meta_box` | `wp_verify_nonce()` in `save_meta_box()` |
+| Bulk Edit AJAX | `astra-blk-nonce` | `astra_nonce` | `check_ajax_referer()` in `save_post_bulk_edit()` |

--- a/internal-docs/architecture.md
+++ b/internal-docs/architecture.md
@@ -1,0 +1,93 @@
+# Architecture
+
+## Overview
+
+Astra Bulk Edit is a single-class WordPress plugin that hooks into the admin post list screens to add Astra meta options to Bulk Edit and Quick Edit interfaces.
+
+```
++-----------------------+
+|  astra-bulk-edit.php  |  Entry point: constants, theme check, loads class
++-----------+-----------+
+            |
+            v (admin only)
++------------------------------------------+
+| Astra_Blk_Meta_Boxes_Bulk_Edit           |
+| (classes/class-astra-blk-meta-boxes-bulk-edit.php) |
+|                                          |
+| - Registers 22 meta options              |
+| - Renders bulk/quick edit form fields    |
+| - Handles save_post (quick edit)         |
+| - Handles AJAX save (bulk edit)          |
+| - Adds hidden data column to post list   |
+| - Enqueues admin JS/CSS                  |
++------------------------------------------+
+            |
+            v
++-------------------+    +--------------------+
+| astra-admin.js    |    | astra-admin.css    |
+| (assets/js/)      |    | (assets/css/)      |
+|                   |    |                    |
+| - Pre-populates   |    | - Styles bulk edit |
+|   quick edit vals  |    |   form fields      |
+| - AJAX bulk save   |    +--------------------+
+| - Sticky header    |
+|   toggle logic     |
++-------------------+
+```
+
+## Boot Sequence
+
+1. WordPress loads `astra-bulk-edit.php`
+2. Theme check: `get_template() === 'astra'` - exits if false
+3. Constants defined (`ASTRA_BLK_VER`, `ASTRA_BLK_FILE`, etc.)
+4. `is_admin()` check - only loads class in admin
+5. Class file loaded, singleton instantiated via `get_instance()`
+6. Constructor registers all WordPress hooks
+
+## Data Flow
+
+### Quick Edit Save
+```
+User clicks "Quick Edit" -> WordPress inline editor opens
+  -> display_quick_edit_custom() renders Astra fields
+  -> User modifies fields, clicks "Update"
+  -> WordPress fires save_post hook
+  -> save_meta_box() validates nonce + capability
+  -> Each meta field sanitized and saved via update_post_meta()
+```
+
+### Bulk Edit Save
+```
+User selects posts -> clicks "Bulk Edit"
+  -> display_quick_edit_custom() renders Astra fields (same hook)
+  -> User modifies fields, clicks "Update"
+  -> astra-admin.js intercepts #bulk_edit click
+  -> Serializes form + sends AJAX to wp_ajax_astra_save_post_bulk_edit
+  -> save_post_bulk_edit() validates nonce + per-post capability
+  -> Iterates posts, sanitizes and saves each meta field
+  -> WordPress default bulk edit proceeds after AJAX completes
+```
+
+### Pre-population (Quick Edit)
+```
+Post list loads -> manage_custom_admin_columns() outputs hidden divs
+  -> Each div contains current meta value for that post
+  -> astra-admin.js overrides inlineEditPost.edit()
+  -> On quick edit open, reads hidden divs and populates select fields
+```
+
+## Singleton Pattern
+
+The class uses a static `$instance` property with `get_instance()` to ensure only one instance exists. The constructor registers all hooks, so the singleton prevents duplicate hook registration.
+
+## Layout Migration
+
+For Astra 4.2.0+, the plugin includes `migrate_layouts()` which maps old layout meta values to the new revamped layout system:
+
+| Old Value | New Container | New Content Style | New Sidebar Style |
+|-----------|--------------|-------------------|-------------------|
+| `plain-container` | `normal-width-container` | `unboxed` | `unboxed` |
+| `boxed-container` | `normal-width-container` | `boxed` | `boxed` |
+| `content-boxed-container` | `normal-width-container` | `boxed` | `unboxed` |
+| `page-builder` | `full-width-container` | `unboxed` | `unboxed` |
+| `narrow-container` | `narrow-width-container` | `unboxed` | `unboxed` |

--- a/internal-docs/codebase-map.md
+++ b/internal-docs/codebase-map.md
@@ -1,0 +1,69 @@
+# Codebase Map
+
+## Directory Structure
+
+```
+astra-bulk-edit/
+├── astra-bulk-edit.php                          # Main plugin file (entry point)
+├── classes/
+│   └── class-astra-blk-meta-boxes-bulk-edit.php # Core class (all plugin logic)
+├── assets/
+│   ├── css/
+│   │   └── astra-admin.css                      # Admin styles for bulk edit UI
+│   └── js/
+│       └── astra-admin.js                       # Quick edit pre-population + AJAX bulk save
+├── languages/
+│   └── astra-bulk-edit.pot                      # Translation template
+├── .github/
+│   └── workflows/
+│       ├── phpcs.yml                            # PHPCS linting CI
+│       ├── push-asset-readme-update.yml         # WP.org asset/readme sync
+│       └── push-to-deploy.yml                   # WP.org deployment
+├── .wordpress-org/                              # WP.org assets (banners, icons, screenshots)
+├── Gruntfile.js                                 # Build tasks (release, i18n, version bump)
+├── package.json                                 # Node dependencies (Grunt plugins)
+├── composer.json                                # PHP dev dependencies (WPCS, PHPCompat)
+├── phpcs.xml.dist                               # PHPCS configuration
+├── readme.txt                                   # WP.org readme (source of truth)
+├── README.md                                    # Generated from readme.txt
+├── .distignore                                  # Files excluded from WP.org distribution
+├── .editorconfig                                # Editor configuration
+├── .gitignore                                   # Git ignore rules
+├── CLAUDE.md                                    # Claude Code project context
+└── .claude/                                     # Claude Code configuration
+    └── settings.json                            # Pre-approved tool permissions
+```
+
+## File Details
+
+### `astra-bulk-edit.php` (31 lines)
+- Plugin header (name, version, author, text domain)
+- Theme gate: `get_template() !== 'astra'` returns early
+- Defines 5 constants: `ASTRA_BLK_VER`, `ASTRA_BLK_FILE`, `ASTRA_BLK_BASE`, `ASTRA_BLK_DIR`, `ASTRA_BLK_URI`
+- Loads class file only in admin context
+
+### `classes/class-astra-blk-meta-boxes-bulk-edit.php` (816 lines)
+This is the heart of the plugin. Single class `Astra_Blk_Meta_Boxes_Bulk_Edit`:
+
+| Method | Lines | Purpose |
+|--------|-------|---------|
+| `get_instance()` | 38-43 | Singleton accessor |
+| `__construct()` | 48-62 | Registers all WP hooks |
+| `setup_admin_init()` | 67-88 | Registers column hooks for all public post types |
+| `setup_bulk_options()` | 93-192 | Defines 22 meta option keys with defaults and sanitize rules |
+| `get_meta_option()` | 197-199 | Static getter for meta options |
+| `save_meta_box()` | 207-252 | Handles quick edit save via `save_post` hook |
+| `save_post_bulk_edit()` | 257-303 | Handles bulk edit save via AJAX |
+| `add_custom_admin_column()` | 311-318 | Adds hidden "Astra Settings" column to post list |
+| `manage_custom_admin_columns()` | 329-370 | Outputs hidden divs with current meta values per post |
+| `display_quick_edit_custom()` | 380-736 | Renders the bulk/quick edit form UI (dropdowns) |
+| `enqueue_admin_scripts_and_styles()` | 741-759 | Enqueues CSS/JS, localizes nonce |
+| `migrate_layouts()` | 768-808 | Maps legacy layout values to Astra 4.2.0+ system |
+
+### `assets/js/astra-admin.js` (175 lines)
+- Overrides `inlineEditPost.edit` to pre-populate quick edit fields
+- Intercepts `#bulk_edit` click for AJAX save before WordPress default behavior
+- Manages sticky header sub-option visibility toggle
+
+### `assets/css/astra-admin.css` (24 lines)
+- Styles for bulk edit form: field widths, column layout, hidden data column

--- a/internal-docs/coding-standards.md
+++ b/internal-docs/coding-standards.md
@@ -1,0 +1,78 @@
+# Coding Standards
+
+## PHP
+
+### WordPress Coding Standards (WPCS)
+The plugin follows WPCS enforced via PHPCS. Configuration in `phpcs.xml.dist`:
+
+- **Rulesets:** WordPress-Core, WordPress-Docs, WordPress-Extra
+- **PHP Compatibility:** 5.3+ (via PHPCompatibility)
+- **Excluded rules:**
+  - `WordPress.PHP.StrictComparisons.LooseComparison`
+  - `WordPress.PHP.StrictInArray.MissingTrueStrict`
+- **Excluded paths:** `node_modules/`, `vendor/`
+
+### Commands
+```bash
+# Check for violations
+composer lint
+
+# Auto-fix violations
+composer format
+```
+
+### Naming Conventions
+- **Class names:** `Astra_Blk_Meta_Boxes_Bulk_Edit` (WordPress-style underscored)
+- **Class files:** `class-astra-blk-meta-boxes-bulk-edit.php` (hyphenated, prefixed with `class-`)
+- **Constants:** `ASTRA_BLK_VER`, `ASTRA_BLK_FILE` (uppercase, plugin-prefixed)
+- **Meta keys:** `site-sidebar-layout`, `ast-main-header-display` (hyphenated, Astra-convention)
+- **Text domain:** `astra-bulk-edit`
+- **Nonce names:** `astra_settings_bulk_meta_box`, `astra-blk-nonce`
+
+### Security Patterns
+- **Nonce verification:** `wp_verify_nonce()` for quick edit, `check_ajax_referer()` for AJAX
+- **Capability checks:** `current_user_can('edit_post', $post_id)` before saving
+- **Input sanitization:** `sanitize_text_field()` for string meta, `absint()` for post IDs, `filter_input()` for URL/number types
+- **Output escaping:** `esc_html()` for text, `esc_attr()` for attributes, `esc_html_e()` for translations
+
+### Class Pattern
+- Singleton via static `$instance` + `get_instance()`
+- All hooks registered in `__construct()`
+- `class_exists()` guard wrapping class definition
+
+## JavaScript
+
+### Style
+- jQuery-dependent (uses `jQuery(document).ready()`)
+- No build step - vanilla JS served directly
+- Dependencies: `jquery`, `inline-edit-post` (WordPress core)
+
+### Conventions
+- `var` declarations (no `let`/`const` - legacy support)
+- `==` comparisons used (matches PHP-side loose comparison style)
+- AJAX via `jQuery.ajax()` with `async: false` for bulk edit (ensures save completes before WordPress default action)
+
+### Script Localization
+```php
+wp_localize_script( 'astra-blk-admin', 'security', array(
+    'nonce' => wp_create_nonce( 'astra-blk-nonce' ),
+));
+```
+Access in JS: `security.nonce`
+
+## CSS
+
+- Minimal admin-only styles
+- No preprocessor (plain CSS)
+- Scoped to `.astra-bulk-settings` and `.column-astra-settings`
+- Uses WordPress admin conventions (`inline-edit-col`, `wp-clearfix`)
+
+## CI/CD
+
+### GitHub Actions (`.github/workflows/`)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `phpcs.yml` | PR/Push | Runs PHPCS linting |
+| `push-asset-readme-update.yml` | Push to master | Syncs WP.org assets and readme |
+| `push-to-deploy.yml` | Push to master | Deploys to WP.org SVN |

--- a/internal-docs/faq.md
+++ b/internal-docs/faq.md
@@ -1,0 +1,59 @@
+# Frequently Asked Questions
+
+## General
+
+### Why does the plugin only work with the Astra theme?
+The plugin edits Astra-specific post meta keys (e.g., `site-sidebar-layout`, `ast-main-header-display`) that are only recognized by the Astra theme. Using it with another theme would save meta values that have no effect on the frontend.
+
+### Why is there no settings page?
+The plugin has no configuration of its own. It simply exposes Astra's existing per-post meta options in the bulk/quick edit interface. The meta options themselves are defined by the Astra theme.
+
+### Does it work with custom post types?
+Yes. It registers for all public post types (`get_post_types(['public' => true])`) except `attachment` and `fl-theme-layout`.
+
+## Development
+
+### How do I add a new bulk edit option?
+1. Add the meta key to `setup_bulk_options()` with default and sanitize values
+2. Add the dropdown HTML in `display_quick_edit_custom()`
+3. Both save handlers (`save_meta_box` and `save_post_bulk_edit`) iterate all registered options automatically - no save code changes needed
+
+### Why are there two save methods?
+WordPress handles quick edit and bulk edit differently:
+- **Quick Edit:** WordPress fires `save_post` with form data in `$_POST` -> `save_meta_box()` handles it
+- **Bulk Edit:** WordPress does NOT fire `save_post` with custom fields for bulk operations, so the plugin uses a custom AJAX handler (`save_post_bulk_edit()`) triggered by JavaScript before WordPress's default bulk action
+
+### Why is the AJAX call synchronous (`async: false`)?
+The bulk edit JS intercepts the "Update" button click, saves Astra meta via AJAX, then triggers the default WordPress bulk edit. The AJAX must complete before the page reloads, hence `async: false`. This is a known jQuery deprecation but is necessary for the current architecture.
+
+### Why is `admin_init` priority set to 999?
+`setup_admin_init()` runs at priority 999 to ensure all post types are already registered by other plugins before the plugin queries `get_post_types()` and registers column hooks.
+
+### How does white-labeling work?
+The fieldset title uses `apply_filters('astra_page_title', __('Astra', 'astra-bulk-edit'))`. Astra Pro's white-label feature filters this to show the custom brand name.
+
+### Why is the "Astra Settings" column hidden?
+The column (`column-astra-settings`) is set to `display: none` in CSS. It only exists to output hidden `<div>` elements containing each post's current meta values, which the JavaScript reads to pre-populate the quick edit form.
+
+## Security
+
+### What security measures are in place?
+- Nonce verification on both save paths
+- Per-post `current_user_can('edit_post')` capability checks
+- `sanitize_text_field()` on all string inputs
+- `absint()` on post ID arrays
+- `esc_html()` / `esc_attr()` on all output
+
+### What was the XSS vulnerability fixed in 1.2.11?
+A Stored XSS vulnerability in the bulk edit AJAX endpoint that could be exploited by Contributor+ users. Fixed by adding proper `sanitize_text_field()` for all meta fields and `esc_html()` for output in admin columns. Reported by Patchstack.
+
+## Build & Release
+
+### How is the plugin released to WP.org?
+Push to `master` triggers the `push-to-deploy.yml` GitHub Action which deploys to WP.org SVN. The `push-asset-readme-update.yml` action syncs screenshots, banners, and readme separately.
+
+### How do I bump the version?
+```bash
+grunt version-bump --ver=1.2.12
+```
+This updates `package.json`, the plugin header `Version:`, and the `ASTRA_BLK_VER` constant.

--- a/internal-docs/glossary.md
+++ b/internal-docs/glossary.md
@@ -1,0 +1,23 @@
+# Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Astra Builder** | The Header Footer Builder introduced in Astra theme, replacing legacy header/footer sections. Detected via `Astra_Builder_Helper::is_header_footer_builder_active()`. |
+| **Astra Pro** | Premium addon for Astra theme. Provides extensions like Sticky Header, Transparent Header, Advanced Headers. Detected via `Astra_Ext_Extension::is_active()`. |
+| **Bulk Edit** | WordPress feature to modify multiple posts at once from the post list screen. Opens a panel above the post list with shared fields. |
+| **Container Layout** | Astra 4.2.0+ setting controlling content width: Normal, Narrow, or Full Width. Meta key: `ast-site-content-layout`. |
+| **Container Style** | Astra 4.2.0+ setting controlling content box appearance: Boxed or Unboxed. Meta key: `site-content-style`. |
+| **Content Layout (Legacy)** | Pre-4.2.0 Astra setting combining container and style: Boxed, Content Boxed, Plain Container, Page Builder. Meta key: `site-content-layout`. |
+| **`.distignore`** | File listing patterns to exclude from WP.org plugin distribution (similar to `.gitignore` but for SVN deploy). |
+| **Header Footer Builder (HFB)** | See "Astra Builder". Meta keys prefixed with `ast-hfb-` are builder-specific. |
+| **`inline-edit-post`** | WordPress core JavaScript that handles the inline editing (quick/bulk edit) interface. The plugin overrides `inlineEditPost.edit` to add pre-population. |
+| **Layout Migration** | Process of converting legacy `site-content-layout` values to the revamped `ast-site-content-layout` + `site-content-style` + `site-sidebar-style` system. Handled by `migrate_layouts()`. |
+| **Meta Option** | A per-post setting stored as WordPress post meta via `update_post_meta()`. The plugin manages 22 meta options. |
+| **No Change** | Sentinel value (`no-change`) used in bulk/quick edit dropdowns meaning "don't modify this setting". Skipped during save. |
+| **Quick Edit** | WordPress feature to edit a single post inline from the post list screen. Opens an inline row with editable fields. |
+| **Revamped Layout** | The new layout option system in Astra 4.2.0+ that separates Container Layout, Container Style, and Sidebar Style into independent options. |
+| **Sidebar Layout** | Astra setting for sidebar position: Left, Right, or No Sidebar. Meta key: `site-sidebar-layout`. |
+| **Sidebar Style** | Astra 4.2.0+ setting for sidebar box appearance: Boxed or Unboxed. Meta key: `site-sidebar-style`. |
+| **Singleton** | Design pattern ensuring only one class instance exists. Used by `Astra_Blk_Meta_Boxes_Bulk_Edit::get_instance()`. |
+| **White Label** | Astra Pro feature allowing agencies to rebrand the theme. Affects this plugin's fieldset title via `astra_page_title` filter. |
+| **WPCS** | WordPress Coding Standards - PHP_CodeSniffer rules for WordPress development. Enforced via `phpcs.xml.dist`. |

--- a/internal-docs/maintenance.md
+++ b/internal-docs/maintenance.md
@@ -1,0 +1,38 @@
+# Maintenance Guide
+
+## When to Update These Docs
+
+| Event | Docs to Update |
+|-------|---------------|
+| New meta option added | `apis.md` (meta keys table), `codebase-map.md` (method table), `ai-agent-guide.md` |
+| New Astra Pro integration | `apis.md` (hooks), `product-vision.md` (scope), `ui-and-copy.md` (conditional UI) |
+| Security fix | `troubleshooting.md`, `faq.md` (security section), `coding-standards.md` if patterns change |
+| Astra version compat change | `architecture.md` (migration table), `glossary.md`, `troubleshooting.md` |
+| Build process change | `README.md` (quick start), `coding-standards.md` (CI/CD), `onboarding.md` |
+| New file/folder added | `codebase-map.md` |
+| Major refactor | `architecture.md`, `codebase-map.md`, `ai-agent-guide.md` |
+
+## How to Update
+
+1. Make code changes first
+2. Update affected doc files - check the table above
+3. Update line numbers in `codebase-map.md` if methods shifted
+4. Keep `apis.md` meta keys table in sync with `setup_bulk_options()`
+
+## Style Guide
+
+- Write in present tense ("The plugin uses..." not "The plugin will use...")
+- Include file paths and line numbers where helpful
+- Use tables for structured data
+- Keep each doc between 500-1,500 words
+- Derive content from actual code, never guess
+
+## Verification
+
+After updating docs, verify:
+- [ ] All file paths mentioned still exist
+- [ ] Line number references are still accurate
+- [ ] Meta key lists match `setup_bulk_options()`
+- [ ] Hook lists match constructor registrations
+- [ ] No secrets or credentials included
+- [ ] `internal-docs/` is still excluded from releases (check `.distignore` and `Gruntfile.js`)

--- a/internal-docs/onboarding.md
+++ b/internal-docs/onboarding.md
@@ -1,0 +1,66 @@
+# Developer Onboarding
+
+## 1-Hour Path (Quick Orientation)
+
+1. **Read `astra-bulk-edit.php`** (31 lines) - Understand the entry point, theme gate, and constants
+2. **Read `classes/class-astra-blk-meta-boxes-bulk-edit.php` constructor** (lines 48-62) - See all hooks registered
+3. **Skim `setup_bulk_options()`** (lines 93-192) - Understand the 22 meta keys
+4. **Open a WordPress admin post list** with the plugin active - See the UI in action
+5. **Try a bulk edit** - Select 2 posts, bulk edit, change a setting, observe the result
+
+After 1 hour you should understand: what the plugin does, where the code lives, and how the UI works.
+
+## 1-Day Path (Working Knowledge)
+
+Everything from the 1-hour path, plus:
+
+1. **Read `save_meta_box()`** (lines 207-252) - Quick edit save flow
+2. **Read `save_post_bulk_edit()`** (lines 257-303) - AJAX bulk save flow
+3. **Read `display_quick_edit_custom()`** (lines 380-736) - Full form rendering with conditionals
+4. **Read `assets/js/astra-admin.js`** (175 lines) - Pre-population and AJAX logic
+5. **Read `manage_custom_admin_columns()`** (lines 329-370) - Hidden data column + layout migration
+6. **Run `composer lint`** - Understand the PHPCS setup
+7. **Read [apis.md](apis.md)** - Reference all hooks, filters, and meta keys
+8. **Read [architecture.md](architecture.md)** - Understand the data flow diagrams
+
+After 1 day you should be able to: fix bugs, add new meta options, and understand the security model.
+
+## 1-Week Path (Full Mastery)
+
+Everything from the 1-day path, plus:
+
+1. **Study the layout migration** in `migrate_layouts()` (lines 768-808) and `manage_custom_admin_columns()` (lines 354-358) - Understand Astra 4.2.0 compat
+2. **Read Astra Pro integration points** - Understand how the plugin detects `Astra_Builder_Helper`, `Astra_Ext_Extension`, `Astra_Target_Rules_Fields`
+3. **Study the sticky header toggle JS** (lines 107-173 in astra-admin.js) - Complex conditional visibility
+4. **Review `.github/workflows/`** - Understand CI/CD pipeline
+5. **Run `grunt release`** - Build a release zip, inspect contents
+6. **Read the changelog in `readme.txt`** - Understand version history and past security fixes
+7. **Add a new meta option end-to-end** as an exercise:
+   - Add key to `setup_bulk_options()`
+   - Add dropdown in `display_quick_edit_custom()`
+   - Test save via both quick edit and bulk edit
+   - Verify the option appears with the correct values
+
+After 1 week you should be able to: make architectural decisions, handle Astra version compatibility, and maintain the plugin independently.
+
+## Environment Setup
+
+### Prerequisites
+- Local WordPress install with Astra theme active
+- Node.js (for Grunt)
+- Composer (for PHPCS)
+
+### Steps
+```bash
+cd wp-content/plugins/astra-bulk-edit
+npm install          # Grunt + build plugins
+composer install     # PHPCS + WordPress coding standards
+```
+
+### Recommended Astra Pro Addons (for full testing)
+- Sticky Header
+- Transparent Header
+- Advanced Headers
+- Header Sections (legacy, pre-builder)
+
+Without Astra Pro, some bulk edit fields will be hidden (this is expected behavior).

--- a/internal-docs/product-vision.md
+++ b/internal-docs/product-vision.md
@@ -1,0 +1,53 @@
+# Product Vision
+
+## Problem
+
+WordPress admins using the Astra theme often need to change meta settings (sidebar layout, header visibility, content width, etc.) on many pages at once. Without this plugin, they must open each page individually and modify settings one by one.
+
+## Solution
+
+Astra Bulk Edit injects Astra's meta options into WordPress's native Bulk Edit and Quick Edit interfaces, allowing admins to modify settings across multiple posts/pages in a single operation.
+
+## Target Personas
+
+### Site Administrator
+- Manages a large WordPress site with many pages
+- Needs to quickly apply consistent layout settings across sections
+- Example: "Make all product pages full-width with no sidebar"
+
+### Theme Customizer
+- Configures Astra theme settings per-page
+- Frequently adjusts header/footer visibility for landing pages
+- Example: "Disable the header on all landing pages at once"
+
+## Scope
+
+The plugin provides bulk/quick edit controls for:
+
+**Layout Settings:**
+- Sidebar layout (left, right, none)
+- Container layout (normal, narrow, full-width) - Astra 4.2.0+
+- Container style (boxed, unboxed) - Astra 4.2.0+
+- Sidebar style (boxed, unboxed) - Astra 4.2.0+
+- Legacy content layout (boxed, content-boxed, plain, page-builder) - pre-4.2.0
+
+**Visibility Toggles:**
+- Primary/Above/Below/Mobile header display
+- Page title visibility
+- Featured image visibility
+- Footer widgets display
+- Footer bar display
+- Breadcrumbs
+
+**Astra Pro Integration:**
+- Transparent header
+- Sticky header (with per-row controls)
+- Page header (Advanced Headers addon)
+
+## What This Plugin Does NOT Do
+
+- Does not add new meta options (uses Astra's existing ones)
+- Does not modify the frontend rendering
+- Does not work with non-Astra themes
+- Does not provide REST API endpoints
+- Does not have settings pages of its own

--- a/internal-docs/troubleshooting.md
+++ b/internal-docs/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+## Plugin Not Loading
+
+**Symptom:** Plugin appears active but no Astra settings in bulk/quick edit.
+
+**Cause:** Astra theme is not the active template.
+
+**Fix:** The plugin checks `get_template() === 'astra'` at load time (`astra-bulk-edit.php:15`). If using a child theme, `get_template()` returns the parent theme slug, so child themes of Astra work. But if Astra is not installed or not active, the plugin silently exits.
+
+## Bulk Edit Fields Not Appearing
+
+**Symptom:** Quick edit shows Astra settings but bulk edit does not (or vice versa).
+
+**Cause:** Both `bulk_edit_custom_box` and `quick_edit_custom_box` use the same handler (`display_quick_edit_custom()`). If one works but not the other, check for JavaScript errors in the browser console.
+
+**Check:** The plugin excludes `product`, `cartflows_flow`, and `cartflows_step` post types from JS enqueue (`enqueue_admin_scripts_and_styles():749`). Also excludes `attachment` and `fl-theme-layout` from column registration.
+
+## Bulk Edit Not Saving
+
+**Symptom:** User clicks "Update" in bulk edit but Astra settings don't change.
+
+**Possible Causes:**
+1. **Nonce mismatch** - Check that `security.nonce` is localized correctly in JS
+2. **AJAX error** - Open browser devtools Network tab, look for `admin-ajax.php` request with `action=astra_save_post_bulk_edit`
+3. **Capability check failing** - User must have `edit_post` capability for each selected post
+4. **"No Change" selected** - Fields with `no-change` value are intentionally skipped during save
+
+## Quick Edit Not Pre-Populating Values
+
+**Symptom:** Quick edit opens with all fields set to "-- No Change --" instead of current values.
+
+**Cause:** The hidden data divs (`.astra-bulk-edit-field-{post_id}`) are not being output or are empty.
+
+**Check:**
+1. Inspect the page source - look for `<div class="astra-bulk-edit-field-{id}">` elements
+2. Verify `manage_custom_admin_columns()` is firing (column must be registered)
+3. Check that `get_post_meta()` returns expected values for the post
+
+## Layout Options Showing Wrong Version
+
+**Symptom:** Seeing legacy layout options (Boxed, Content Boxed, etc.) instead of new revamped options (Normal, Narrow, Full Width), or vice versa.
+
+**Cause:** The form conditionally renders based on `ASTRA_THEME_VERSION` compared to `4.2.0` (`display_quick_edit_custom():393`).
+
+**Fix:** Ensure the correct version of Astra theme is active. The migration in `migrate_layouts()` handles display of existing data, but the form fields are version-locked.
+
+## Sticky Header Sub-Options Not Toggling
+
+**Symptom:** Changing "Sticky Header" dropdown doesn't show/hide the sub-options.
+
+**Cause:** JavaScript toggle logic in `astra-admin.js:107-161`.
+
+**Check:**
+1. Browser console for JS errors
+2. Ensure `inline-edit-post` script is loaded (it's a dependency)
+3. The toggle uses jQuery `slideDown()`/`slideUp()` on CSS classes: `.sticky-header-above-stick-meta`, `.sticky-header-main-stick-meta`, `.sticky-header-below-stick-meta`
+
+## PHPCS Failures
+
+**Symptom:** `composer lint` reports violations.
+
+**Common fixes:**
+- Missing docblocks: Add `@since x.x.x` tags
+- Escaping: Use `esc_html()`, `esc_attr()`, `esc_url()` for all output
+- Sanitization: Use `sanitize_text_field()` for POST input
+- Yoda conditions: Put literal on the left (`'value' === $var`)
+
+## Grunt Release Missing Files
+
+**Symptom:** Release zip is missing expected files or includes dev files.
+
+**Check:** The `copy.main.src` exclusion list in `Gruntfile.js:60-87`. Files must NOT match any exclusion pattern to be included. Verify `.distignore` matches for WP.org deploys.

--- a/internal-docs/ui-and-copy.md
+++ b/internal-docs/ui-and-copy.md
@@ -1,0 +1,79 @@
+# UI and Copy
+
+## User Journey
+
+### Bulk Edit Flow
+1. Admin navigates to Posts/Pages list screen
+2. Selects multiple posts via checkboxes
+3. Chooses "Edit" from Bulk Actions dropdown, clicks "Apply"
+4. WordPress opens bulk edit panel
+5. **Astra Settings fieldset appears** with dropdown controls
+6. Admin selects desired values (or leaves as "-- No Change --")
+7. Clicks "Update"
+8. Plugin JS intercepts click, sends AJAX request to save Astra meta
+9. After AJAX completes, WordPress default bulk edit proceeds
+
+### Quick Edit Flow
+1. Admin hovers over a post in the list
+2. Clicks "Quick Edit"
+3. WordPress opens inline edit row
+4. **Astra Settings appear** with dropdowns pre-populated with current values
+5. Admin modifies values
+6. Clicks "Update"
+7. WordPress fires `save_post`, plugin saves meta via `save_meta_box()`
+
+## UI Layout
+
+The bulk/quick edit form is organized in three float-left columns:
+
+**Left Column:**
+- Sidebar Layout (or Container Layout + Container Style + Sidebar Layout + Sidebar Style for Astra 4.2.0+)
+- Extension point: `astra_meta_bulk_edit_left_bottom` action hook
+
+**Center Column:**
+- Primary Header (enabled/disabled)
+- Above Header (conditional on theme config)
+- Below Header (conditional on theme config)
+- Mobile Header (conditional on builder active)
+- Transparent Header (conditional on theme option)
+- Page Header (Astra Pro Advanced Headers)
+- Sticky Header + sub-options (Astra Pro Sticky Header)
+- Extension point: `astra_meta_bulk_edit_center_bottom` action hook
+
+**Right Column:**
+- Breadcrumbs (conditional on position != none)
+- Title Visibility
+- Featured Image
+- Footer Widgets (conditional on layout != disabled)
+- Footer Bar (conditional on layout != disabled)
+
+## Microcopy
+
+### Dropdown Default
+All dropdowns default to `"-- No Change --"` (value: `no-change`), meaning the existing meta value is preserved. This is critical for bulk edit where you may only want to change one setting.
+
+### Option Labels
+- `"Customizer Setting"` (value: `default`) - Inherits from Astra Customizer
+- `"Enabled"` / `"Disabled"` - Toggle options
+- Layout-specific labels match Astra Customizer naming
+
+### Fieldset Title
+Displays as `"{Theme Name} Settings"` where theme name comes from `astra_page_title` filter. Supports Astra white-labeling.
+
+### Hidden Column
+The "Astra Settings" column in the post list is hidden via CSS (`display: none`). It exists solely to hold data attributes for quick edit pre-population.
+
+## Conditional UI
+
+Several fields only appear based on theme/addon configuration:
+- Above/Below Header: Only if header row is populated (builder) or addon is active with non-disabled layout
+- Mobile Header: Only if header footer builder is active and rows are populated
+- Transparent Header: Only if not globally disabled
+- Sticky Header section: Only if Astra Pro Sticky Header addon is active
+- Advanced Headers: Only if addon active and not a Beaver Builder Themer layout
+- Breadcrumbs: Only if breadcrumb position is not "none"
+- Footer Widgets/Bar: Only if not globally disabled
+
+## Sticky Header Toggle Behavior
+
+When "Sticky Header" is set to "Enabled", the sub-options (Stick Above/Primary/Below Header) slide down. When set to anything else, they slide up. Additionally, if all three header rows (above, primary, below) are individually disabled, the entire sticky header option hides.


### PR DESCRIPTION
## Summary

Set up Claude Code project config and internal documentation for developer onboarding and AI agent understanding.

## What's Included

### Claude Code Config
- `CLAUDE.md` — Project context, commands, conventions
- `.claude/settings.json` — Pre-approved tool permissions

### Internal Documentation
- `internal-docs/README.md` — Project overview, quick start, doc index
- `internal-docs/product-vision.md` — Problem, solution, personas, scope
- `internal-docs/architecture.md` — Boot sequence, data flow, layout migration
- `internal-docs/codebase-map.md` — Directory tree, file details, method tables
- `internal-docs/apis.md` — AJAX endpoint, hooks, filters, meta keys, nonces
- `internal-docs/coding-standards.md` — WPCS config, naming, security patterns, CI/CD
- `internal-docs/ui-and-copy.md` — User journeys, UI layout, microcopy, conditionals
- `internal-docs/onboarding.md` — 1-hour / 1-day / 1-week developer paths
- `internal-docs/ai-agent-guide.md` — Code locations, patterns, pitfalls, security checklist
- `internal-docs/troubleshooting.md` — Common problems with symptoms and fixes
- `internal-docs/faq.md` — Development, security, and build FAQs
- `internal-docs/glossary.md` — Technical terms and definitions
- `internal-docs/maintenance.md` — When and how to update docs

### Build Exclusions
- Updated `.distignore` to exclude dev-only files from WP.org
- Updated `Gruntfile.js` to exclude from release zip
- Added `.claude/settings.local.json` to `.gitignore`

## Notes
- All doc content derived from actual code (not guessed)
- `internal-docs/` is excluded from production builds
- No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)