### PR TITLE
Wordpress 7.0 Compatibility

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -7,6 +7,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -15,4 +15,5 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true
         SLUG: astra-bulk-edit

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -7,8 +7,18 @@ jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - name: Verify release tag is reachable from master
+      run: |
+        git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+          echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from master. Refusing to deploy."
+          exit 1
+        fi
     - name: WordPress Plugin Deploy
       uses: Nikschavan/action-wordpress-plugin-deploy@develop
       env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit  
 **Requires at least:** 4.4  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Stable tag:** 1.2.11  
 **Requires PHP:** 5.2  
 **License:** GPLv2 or later  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: bulk edit Astra meta settings, Astra meta settings, meta settings bulk edit, wordpress bulk edit plugin, page bulk edit, post bulk edit
 Requires at least: 4.4
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.2.11
 Requires PHP: 5.2
 License: GPLv2 or later


### PR DESCRIPTION
## WordPress 7.0 Compatibility
- Tested with 7.0 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

## Deploy workflow hardening (ports [astra-sites#886](https://github.com/brainstormforce/astra-sites/pull/886))
- Added `environment: production` to the deploy jobs so org-level `SVN_*` secrets are only reachable from workflows running on `master` + tags (via a scoped `production` GitHub Environment restricted to those refs).
- Added a guard in `push-to-deploy.yml` that refuses to deploy a tag not reachable from `master`.